### PR TITLE
Feature: Add support for toggling the drag and drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,50 @@ The `ReorderableItem` composable is at the same time a `DraggableItem` and a `dr
 
 > For more details, check out the [sample](https://github.com/MohamedRejeb/compose-dnd/tree/main/sample/common/src/commonMain/kotlin)
 
+
+### Toggleable Drag and Drop
+
+If you want the ability to toggle drag and drop functionality, you can use the
+`ToggleableDragAndDropContainer` or `ToggleableReorderContainer` composable. Then use the scoped
+item composable `ToggleableDragAndDropContainerScope.DraggableItem` or
+`ToggleableReorderContainerScope.ReorderableItem`.
+
+For `DragAndDropContainer`:
+
+```kotlin
+val dragAndDropState = rememberDragAndDropState()
+var enabled by remember { mutableStateOf(false) }
+
+ToggleableDragAndDropContainer(
+    state = dragAndDropState,
+    enabled = enabled,
+) {
+    DraggableItem(
+        // ...
+    ) {
+        // Draggable item content
+    }
+}
+```
+
+For `ReorderContainer`:
+
+```kotlin
+val reorderState = rememberReorderState()
+var enabled by remember { mutableStateOf(false) }
+
+ToggleableReorderContainer(
+    state = reorderState,
+    enabled = enabled,
+) {
+    ReorderableItem(
+        // ...
+    ) {
+        // Reorderable item content
+    }
+}
+```
+
 ## Contribution
 If you've found an error in this sample, please file an issue. <br>
 Feel free to help out by sending a pull request :heart:.

--- a/compose-dnd/src/commonMain/kotlin/com/mohamedrejeb/compose/dnd/ToggleableDragAndDropContainer.kt
+++ b/compose-dnd/src/commonMain/kotlin/com/mohamedrejeb/compose/dnd/ToggleableDragAndDropContainer.kt
@@ -1,0 +1,72 @@
+package com.mohamedrejeb.compose.dnd
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import com.mohamedrejeb.compose.dnd.annotation.ExperimentalDndApi
+import com.mohamedrejeb.compose.dnd.drag.DraggableItemScope
+
+@OptIn(ExperimentalDndApi::class)
+@Composable
+fun <T> ToggleableDragAndDropContainer(
+    state: DragAndDropState<T>,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    content: @Composable ToggleableDragAndDropScope.() -> Unit,
+) {
+    val scope = remember(enabled) { ToggleableDragAndDropScope(enabled) }
+
+    if (!enabled) content(scope)
+    else {
+        DragAndDropContainer(
+            state = state,
+            modifier = modifier,
+            content = { content(scope) },
+        )
+    }
+}
+
+@OptIn(ExperimentalDndApi::class)
+class ToggleableDragAndDropScope(
+    private val enabled: Boolean,
+) {
+
+    @OptIn(ExperimentalDndApi::class)
+    @Composable
+    fun <T> DraggableItem(
+        modifier: Modifier = Modifier,
+        key: Any,
+        data: T,
+        state: DragAndDropState<T>,
+        dragAfterLongPress: Boolean = state.dragAfterLongPress,
+        dropTargets: List<Any> = emptyList(),
+        dropAnimationSpec: AnimationSpec<Offset> = SpringSpec(),
+        draggableContent: (@Composable () -> Unit)? = null,
+        content: @Composable DraggableItemScope.() -> Unit,
+    ) {
+        if (!enabled) {
+            val fakeScope = remember {
+                object : DraggableItemScope {
+                    override val isDragging: Boolean = false
+                    override val key: Any = key
+                }
+            }
+            content(fakeScope)
+        } else {
+            com.mohamedrejeb.compose.dnd.drag.DraggableItem(
+                modifier = modifier,
+                key = key,
+                data = data,
+                state = state,
+                dragAfterLongPress = dragAfterLongPress,
+                dropTargets = dropTargets,
+                dropAnimationSpec = dropAnimationSpec,
+                draggableContent = draggableContent,
+                content = content,
+            )
+        }
+    }
+}

--- a/compose-dnd/src/commonMain/kotlin/com/mohamedrejeb/compose/dnd/reorder/ToggleableReorderContainer.kt
+++ b/compose-dnd/src/commonMain/kotlin/com/mohamedrejeb/compose/dnd/reorder/ToggleableReorderContainer.kt
@@ -1,0 +1,80 @@
+package com.mohamedrejeb.compose.dnd.reorder
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import com.mohamedrejeb.compose.dnd.annotation.ExperimentalDndApi
+import com.mohamedrejeb.compose.dnd.drag.DraggedItemState
+
+@OptIn(ExperimentalDndApi::class)
+@Composable
+fun <T> ToggleableReorderContainer(
+    state: ReorderState<T>,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    content: @Composable ToggleableReorderContainerScope.() -> Unit,
+) {
+    val scope = remember(enabled) { ToggleableReorderContainerScope(enabled) }
+
+    if (!enabled) content(scope)
+    else {
+        ReorderContainer(
+            state = state,
+            modifier = modifier,
+            content = { content(scope) },
+        )
+    }
+}
+
+@OptIn(ExperimentalDndApi::class)
+class ToggleableReorderContainerScope(
+    private val enabled: Boolean,
+) {
+
+    @OptIn(ExperimentalDndApi::class)
+    @Composable
+    fun <T> ReorderableItem(
+        modifier: Modifier = Modifier,
+        state: ReorderState<T>,
+        key: Any,
+        data: T,
+        zIndex: Float = 0f,
+        dragAfterLongPress: Boolean = state.dndState.dragAfterLongPress,
+        dropTargets: List<Any> = emptyList(),
+        onDrop: (state: DraggedItemState<T>) -> Unit = {},
+        onDragEnter: (state: DraggedItemState<T>) -> Unit = {},
+        onDragExit: (state: DraggedItemState<T>) -> Unit = {},
+        dropAnimationSpec: AnimationSpec<Offset> = SpringSpec(),
+        draggableContent: (@Composable () -> Unit)? = null,
+        content: @Composable ReorderableItemScope.() -> Unit,
+    ) {
+        if (!enabled) {
+            val fakeScope = remember {
+                object : ReorderableItemScope {
+                    override val isDragging: Boolean = false
+                    override val key: Any = key
+                }
+            }
+            content(fakeScope)
+        } else {
+            com.mohamedrejeb.compose.dnd.reorder.ReorderableItem(
+                modifier = modifier,
+                state = state,
+                key = key,
+                data = data,
+                zIndex = zIndex,
+                dragAfterLongPress = dragAfterLongPress,
+                dropTargets = dropTargets,
+                onDrop = onDrop,
+                onDragEnter = onDragEnter,
+                onDragExit = onDragExit,
+                dropAnimationSpec = dropAnimationSpec,
+                draggableContent = draggableContent,
+                content = content,
+            )
+        }
+    }
+}


### PR DESCRIPTION
I'm using `compose-dnd` in my app, and I needed to be able to toggle whether or not the drag-and-drop was enabled. I couldn't see a built-in solution, so I created a wrapper `@Composable` that adds this functionality.  I decided I might as well open up a PR and see if its something you'd want to add to the library.

Let me know what you think 👍 